### PR TITLE
Restrict GPT Boost to conversation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GPT Boost reduces lag on long ChatGPT conversations by **lazy-loading**: it show
 - Click **Show older** in the sticky pill to reveal the next batch (default **10**).
 - Optional auto-reveal when you scroll to the top.
 - Simple, non-intrusive UI; per-site content script (no background service worker).
-- Works on `chatgpt.com` (and `chat.openai.com` for backward compatibility).
+- Works on conversation URLs like `https://chatgpt.com/share/*` and `https://chatgpt.com/c/*`.
 
 ## Install (Developer Mode)
 1. Download the ZIP from the releases tab and extract it.

--- a/content.js
+++ b/content.js
@@ -1,4 +1,9 @@
 (() => {
+    // Only run on conversation URLs like /share/* or /c/*
+    if (!/^\/(share|c)\//.test(location.pathname)) {
+        return;
+    }
+
     // Enable verbose logging to debug infinite loading issues
     const DEBUG = false;
     const log = (...args) => {

--- a/manifest.json
+++ b/manifest.json
@@ -16,8 +16,8 @@
   "content_scripts": [
     {
       "matches": [
-        "*://chatgpt.com/*",
-        "*://chat.openai.com/*"
+        "*://chatgpt.com/share/*",
+        "*://chatgpt.com/c/*"
       ],
       "js": [
         "content.js"

--- a/manifest.json
+++ b/manifest.json
@@ -16,8 +16,8 @@
   "content_scripts": [
     {
       "matches": [
-        "*://chatgpt.com/share/*",
-        "*://chatgpt.com/c/*"
+        "*://chatgpt.com/*",
+        "*://chat.openai.com/*"
       ],
       "js": [
         "content.js"


### PR DESCRIPTION
## Summary
- Inject GPT Boost only on ChatGPT conversation pages (`chatgpt.com/share/*` and `chatgpt.com/c/*`)
- Document the new limited URL scope in the README

## Testing
- `npx --yes web-ext lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/web-ext)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c720599483299750faae8a708418