### PR TITLE
Fix premature autoload triggering on initial chat load

### DIFF
--- a/content.js
+++ b/content.js
@@ -100,6 +100,7 @@
     let lastApply = {total: null, hiddenTop: null};
     let currentStatus = {total: null, hiddenTop: null};
     let sawZeroThenGrew = false; // detect chat reload: total 0 -> >0 transition
+    let conversationLoaded = false; // ensure autoload waits for initial collapse
 
     // Find the main container
     function findContainer() {
@@ -203,7 +204,8 @@
                 threadContainer.prepend(topSentinel);
                 topSentinelObserver = new IntersectionObserver((entries) => {
                     for (const e of entries) {
-                        if (e.isIntersecting &&
+                        if (conversationLoaded &&
+                            e.isIntersecting &&
                             currentStatus.total > 0 &&
                             currentStatus.total !== currentStatus.visible &&
                             threadContainer.scrollHeight > threadContainer.clientHeight) {
@@ -326,6 +328,8 @@
                 placeholder.remove();
             }
         }
+
+        conversationLoaded = true;
     }
 
     function revealOlderText(hiddenCountTop) {
@@ -495,6 +499,7 @@
             hiddenCountTop = 0;
             hiddenCountBottom = 0;
             sawZeroThenGrew = false;
+            conversationLoaded = false;
             // reattach observer for new container without timers
             observeDom();
             scheduleApplyWindowing("route change");


### PR DESCRIPTION
## Summary
- scope IntersectionObserver to chat scroll container to avoid triggering on page load
- check for overflow before auto-revealing older messages

## Testing
- `node --check content.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d09eb91c8329aaa2a5a0848df79b