### PR TITLE
Use browser-agnostic storage without build tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GPT Boost (Chrome/Edge extension)
+# GPT Boost (Chrome/Edge/Firefox extension)
 
 GPT Boost reduces lag on long ChatGPT conversations by **lazy-loading**: it shows only the latest messages and hides older ones until you scroll to the top or click **Show older**. Thresholds are configurable.
 

--- a/options.js
+++ b/options.js
@@ -4,24 +4,39 @@ const DEFAULTS = {
   autoloadOnScroll: true,
 };
 
-function load() {
-  chrome.storage.sync.get(DEFAULTS, (res) => {
-    document.getElementById("maxVisible").value = res.maxVisible;
-    document.getElementById("batchSize").value = res.batchSize;
-    document.getElementById("autoloadOnScroll").checked = !!res.autoloadOnScroll;
-  });
+const BROWSER = typeof window.browser !== "undefined" ? window.browser : window.chrome;
+
+function storageGet(defaults) {
+  if (BROWSER.storage && BROWSER.storage.sync && BROWSER.storage.sync.get.length <= 1) {
+    return BROWSER.storage.sync.get(defaults);
+  }
+  return new Promise((resolve) => BROWSER.storage.sync.get(defaults, resolve));
 }
 
-function save(e) {
+function storageSet(values) {
+  if (BROWSER.storage && BROWSER.storage.sync && BROWSER.storage.sync.set.length <= 1) {
+    return BROWSER.storage.sync.set(values);
+  }
+  return new Promise((resolve) => BROWSER.storage.sync.set(values, resolve));
+}
+
+async function load() {
+  const res = await storageGet(DEFAULTS);
+  document.getElementById("maxVisible").value = res.maxVisible;
+  document.getElementById("batchSize").value = res.batchSize;
+  document.getElementById("autoloadOnScroll").checked = !!res.autoloadOnScroll;
+}
+
+async function save(e) {
   e.preventDefault();
   const maxVisible = Math.max(1, parseInt(document.getElementById("maxVisible").value || "10", 10));
   const batchSize = Math.max(1, parseInt(document.getElementById("batchSize").value || "10", 10));
   const autoloadOnScroll = !!document.getElementById("autoloadOnScroll").checked;
-  chrome.storage.sync.set({ maxVisible, batchSize, autoloadOnScroll });
+  await storageSet({ maxVisible, batchSize, autoloadOnScroll });
 }
 
 function reset() {
-  chrome.storage.sync.set(DEFAULTS, load);
+  storageSet(DEFAULTS).then(load);
 }
 
 document.getElementById("form").addEventListener("submit", save);


### PR DESCRIPTION
## Summary
- add a cross-browser storage shim in the content script for Chrome/Firefox support
- update the options page to use the same browser-agnostic storage helpers
- simplify docs by removing Node-based build steps and focusing on manual installation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba71260a34832987429a39f365d39b