### PR TITLE
feat: trim oldest message on new arrivals

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ GPT Boost reduces lag on long ChatGPT conversations by **lazy-loading**: it show
 - Auto-collapses older messages when a chat exceeds *Max visible messages* (default **10**).
 - Click **Show older** in the sticky pill to reveal the next batch (default **10**).
 - Optional auto-reveal when you scroll to the top.
+- Optional trimming of the oldest visible message when new ones arrive.
 - Simple, non-intrusive UI; per-site content script (no background service worker).
 - Works on conversation URLs like `https://chatgpt.com/share/*` and `https://chatgpt.com/c/*`.
 
@@ -24,6 +25,7 @@ Open the extension’s **Options** page from your browser’s extensions list.
 - **Max visible messages**: how many messages are kept on-screen (default 10).
 - **Batch size**: how many older messages are revealed per click/scroll (default 10).
 - **Auto-reveal on scroll**: automatically reveal older messages when you reach the top.
+- **Hide the oldest message when a new appears**: keep the current number of visible messages constant (default on).
 
 ## Notes
 - GPT Boost hides older DOM nodes (display: none) to reduce layout/paint cost. It does **not** modify or exfiltrate content.

--- a/content.js
+++ b/content.js
@@ -12,9 +12,11 @@
         maxVisible: 10,         // show at most last N messages
         batchSize: 10,          // number of messages to reveal/hide in a batch
         autoloadOnScroll: true, // reveal older messages when user scrolls to top
+        hideOldestOnNew: true,  // hide oldest visible message when new ones arrive
     });
 
     let settings = {...DEFAULTS};
+    let visibleLimit = DEFAULTS.maxVisible; // dynamic visible count when auto-hiding on new
 
     // Utility: get settings from storage
     function loadSettings() {
@@ -23,12 +25,14 @@
             try {
                 chrome.storage.sync.get(DEFAULTS, (res) => {
                     settings = {...DEFAULTS, ...res};
+                    visibleLimit = settings.maxVisible;
                     log("loadSettings: resolved from chrome.storage.sync", settings);
                     resolve(settings);
                 });
             } catch (e) {
                 // Firefox/quasi environments might not have chrome.*; fallback to defaults
                 settings = {...DEFAULTS};
+                visibleLimit = settings.maxVisible;
                 log("loadSettings: using DEFAULTS due to error", e);
                 resolve(settings);
             }
@@ -46,6 +50,7 @@
                 for (const k of Object.keys(DEFAULTS)) {
                     if (k in changes) {
                         settings[k] = changes[k].newValue;
+                        if (k === 'maxVisible') visibleLimit = settings.maxVisible;
                         changed = true;
                     }
                 }
@@ -248,12 +253,17 @@
 
         // messages present; proceed normally
 
-        // If we haven't hidden anything yet or messages changed radically, recalc hidden top
-        if (hiddenCountTop + threshold > total) {
-            hiddenCountTop = Math.max(0, total - threshold);
+        if (settings.hideOldestOnNew) {
+            if (visibleLimit < threshold) visibleLimit = threshold;
+            hiddenCountTop = Math.max(0, total - visibleLimit);
         } else {
-            // Keep hiddenCountTop bounded
-            hiddenCountTop = Math.min(hiddenCountTop, Math.max(0, total - threshold));
+            // If we haven't hidden anything yet or messages changed radically, recalc hidden top
+            if (hiddenCountTop + threshold > total) {
+                hiddenCountTop = Math.max(0, total - threshold);
+            } else {
+                // Keep hiddenCountTop bounded
+                hiddenCountTop = Math.min(hiddenCountTop, Math.max(0, total - threshold));
+            }
         }
         log("applyWindowing: hiddenCountTop after calc", hiddenCountTop);
 
@@ -264,6 +274,7 @@
             // compute hiddenCountTop to collapse now
             const threshold = Math.max(1, Number(settings.maxVisible) || DEFAULTS.maxVisible);
             hiddenCountTop = Math.max(0, total - threshold);
+            if (settings.hideOldestOnNew) visibleLimit = threshold;
         }
 
         // Skip redundant apply if nothing changed
@@ -329,6 +340,7 @@
         const batchSize = Math.max(1, Number(settings.batchSize) || DEFAULTS.batchSize);
         const before = hiddenCountTop;
         hiddenCountTop = Math.max(0, hiddenCountTop - batchSize);
+        visibleLimit += before - hiddenCountTop;
         log("revealOlder: hiddenCountTop", {before, after: hiddenCountTop, batchSize, total: messages.length});
 
         let placeholder = container.querySelector(".gpt-boost-hidden-placeholder");
@@ -357,6 +369,7 @@
         const total = messages.length;
         const threshold = Math.max(1, Number(settings.maxVisible) || DEFAULTS.maxVisible);
         hiddenCountTop = Math.max(0, total - threshold);
+        visibleLimit = threshold;
         log("collapseToThreshold: computing hiddenCountTop", {total, threshold, hiddenCountTop});
         applyWindowing();
         // Scroll to bottom after collapsing to keep the newest in view
@@ -481,6 +494,7 @@
             hiddenCountTop = 0;
             hiddenCountBottom = 0;
             sawZeroThenGrew = false;
+            visibleLimit = settings.maxVisible;
             // reattach observer for new container without timers
             observeDom();
             scheduleApplyWindowing("route change");

--- a/options.html
+++ b/options.html
@@ -23,6 +23,10 @@
             <input type="checkbox" id="autoloadOnScroll">
             Reveal older messages automatically when I scroll to the top
         </label>
+        <label class="row">
+            <input type="checkbox" id="hideOldestOnNew">
+            Hide the oldest message when a new appears
+        </label>
         <div class="actions">
             <button type="submit">Save</button>
             <button type="button" id="reset">Reset to defaults</button>

--- a/options.js
+++ b/options.js
@@ -2,6 +2,7 @@ const DEFAULTS = {
   maxVisible: 10,
   batchSize: 10,
   autoloadOnScroll: true,
+  hideOldestOnNew: true,
 };
 
 function load() {
@@ -9,6 +10,7 @@ function load() {
     document.getElementById("maxVisible").value = res.maxVisible;
     document.getElementById("batchSize").value = res.batchSize;
     document.getElementById("autoloadOnScroll").checked = !!res.autoloadOnScroll;
+    document.getElementById("hideOldestOnNew").checked = !!res.hideOldestOnNew;
   });
 }
 
@@ -17,7 +19,8 @@ function save(e) {
   const maxVisible = Math.max(1, parseInt(document.getElementById("maxVisible").value || "10", 10));
   const batchSize = Math.max(1, parseInt(document.getElementById("batchSize").value || "10", 10));
   const autoloadOnScroll = !!document.getElementById("autoloadOnScroll").checked;
-  chrome.storage.sync.set({ maxVisible, batchSize, autoloadOnScroll });
+  const hideOldestOnNew = !!document.getElementById("hideOldestOnNew").checked;
+  chrome.storage.sync.set({ maxVisible, batchSize, autoloadOnScroll, hideOldestOnNew });
 }
 
 function reset() {


### PR DESCRIPTION
## Summary
- add option to hide oldest visible message when new messages arrive
- maintain dynamic visible window with `visibleLimit`
- expose toggle in options page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
Completing this change request: https://github.com/fatidian1/GPT-Boost/issues/2