### PR TITLE
Add translations for additional locales

### DIFF
--- a/assets/locales/ar/messages.json
+++ b/assets/locales/ar/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "حمِّل محادثات ChatGPT الطويلة تدريجيًا عبر عرض أحدث الرسائل فقط (قابل للتخصيص). يقلل التأخير في الدردشات الطويلة."
+  },
+  "statusBar": {
+    "message": "GPT Boost · مرئية $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "تم إخفاء رسالة قديمة واحدة — انقر لتحميل $1 التالية"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "تم إخفاء $1 رسالة قديمة — انقر لتحميل $2 التالية"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – الإعدادات"
+  },
+  "labelMaxVisible": {
+    "message": "الحد الأقصى للرسائل الظاهرة"
+  },
+  "defaultNumber": {
+    "message": "الإعداد الافتراضي: $1"
+  },
+  "labelBatchSize": {
+    "message": "حجم الدفعة (لكل إظهار)"
+  },
+  "labelAutoload": {
+    "message": "اعرض الرسائل الأقدم تلقائيًا عند التمرير إلى الأعلى"
+  },
+  "labelHideOldest": {
+    "message": "إخفاء أقدم رسالة عند ظهور رسالة جديدة"
+  },
+  "save": {
+    "message": "حفظ"
+  },
+  "reset": {
+    "message": "إعادة التعيين إلى الافتراضي"
+  },
+  "hintApply": {
+    "message": "يتم تطبيق التغييرات فورًا على علامات تبويب ChatGPT المفتوحة."
+  },
+  "footerDescription": {
+    "message": "$1 يقلل التأخير في المحادثات الطويلة عبر إبقاء نافذة من الرسائل فقط داخل DOM."
+  },
+  "footerSupportPrefix": {
+    "message": "إذا أعجبك هذا الامتداد، فكر في أن تشتري لي "
+  },
+  "footerSupportLinkText": {
+    "message": "قهوة"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "تم حفظ الإعدادات"
+  },
+  "settingsRestored": {
+    "message": "تمت إعادة الإعدادات إلى الوضع الافتراضي"
+  },
+  "showOlder": {
+    "message": "عرض الأقدم"
+  },
+  "showOlderTitle": {
+    "message": "عرض الرسائل الأقدم"
+  },
+  "collapse": {
+    "message": "طي"
+  },
+  "collapseTitle": {
+    "message": "طي الرسائل الأقدم"
+  },
+  "dragTitle": {
+    "message": "سحب"
+  },
+  "statusActive": {
+    "message": "GPT Boost نشط"
+  }
+}

--- a/assets/locales/cs/messages.json
+++ b/assets/locales/cs/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Postupně načítejte dlouhé konverzace ChatGPT zobrazením pouze nejnovějších zpráv (lze nastavit). Snižuje zpoždění u dlouhých chatů."
+  },
+  "statusBar": {
+    "message": "GPT Boost · viditelné $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "Skryta 1 starší zpráva — kliknutím načtete dalších $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "Skryto $1 starších zpráv — kliknutím načtete dalších $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Možnosti"
+  },
+  "labelMaxVisible": {
+    "message": "Maximální počet viditelných zpráv"
+  },
+  "defaultNumber": {
+    "message": "Výchozí: $1"
+  },
+  "labelBatchSize": {
+    "message": "Velikost dávky (na jedno zobrazení)"
+  },
+  "labelAutoload": {
+    "message": "Automaticky zobrazit starší zprávy při posunu na začátek"
+  },
+  "labelHideOldest": {
+    "message": "Skrýt nejstarší zprávu, když se objeví nová"
+  },
+  "save": {
+    "message": "Uložit"
+  },
+  "reset": {
+    "message": "Obnovit výchozí"
+  },
+  "hintApply": {
+    "message": "Změny se okamžitě použijí na otevřených kartách ChatGPT."
+  },
+  "footerDescription": {
+    "message": "$1 snižuje zpoždění v dlouhých konverzacích tím, že v DOM ponechá pouze okno zpráv."
+  },
+  "footerSupportPrefix": {
+    "message": "Pokud se vám toto rozšíření líbí, zvažte, že mi koupíte "
+  },
+  "footerSupportLinkText": {
+    "message": "kávu"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Nastavení uloženo"
+  },
+  "settingsRestored": {
+    "message": "Nastavení obnoveno na výchozí hodnoty"
+  },
+  "showOlder": {
+    "message": "Zobrazit starší"
+  },
+  "showOlderTitle": {
+    "message": "Zobrazit starší zprávy"
+  },
+  "collapse": {
+    "message": "Sbalit"
+  },
+  "collapseTitle": {
+    "message": "Sbalit starší zprávy"
+  },
+  "dragTitle": {
+    "message": "Přetáhnout"
+  },
+  "statusActive": {
+    "message": "GPT Boost aktivní"
+  }
+}

--- a/assets/locales/de/messages.json
+++ b/assets/locales/de/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Lädt lange ChatGPT-Unterhaltungen nach Bedarf, indem nur die neuesten Nachrichten angezeigt werden (konfigurierbar). Reduziert Verzögerungen in langen Chats."
+  },
+  "statusBar": {
+    "message": "GPT Boost · sichtbar $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 ältere Nachricht verborgen — klicken, um die nächsten $1 zu laden"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 ältere Nachrichten verborgen — klicken, um die nächsten $2 zu laden"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Optionen"
+  },
+  "labelMaxVisible": {
+    "message": "Maximale Anzahl sichtbarer Nachrichten"
+  },
+  "defaultNumber": {
+    "message": "Standard: $1"
+  },
+  "labelBatchSize": {
+    "message": "Stapelgröße (pro Anzeige)"
+  },
+  "labelAutoload": {
+    "message": "Ältere Nachrichten automatisch anzeigen, wenn ich nach oben scrolle"
+  },
+  "labelHideOldest": {
+    "message": "Älteste Nachricht ausblenden, wenn eine neue erscheint"
+  },
+  "save": {
+    "message": "Speichern"
+  },
+  "reset": {
+    "message": "Auf Standard zurücksetzen"
+  },
+  "hintApply": {
+    "message": "Änderungen gelten sofort für geöffnete ChatGPT-Tabs."
+  },
+  "footerDescription": {
+    "message": "$1 verringert Verzögerungen in langen Unterhaltungen, indem nur ein Nachrichtenfenster im DOM bleibt."
+  },
+  "footerSupportPrefix": {
+    "message": "Wenn dir diese Erweiterung gefällt, spendiere mir doch "
+  },
+  "footerSupportLinkText": {
+    "message": "einen Kaffee"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Einstellungen gespeichert"
+  },
+  "settingsRestored": {
+    "message": "Einstellungen auf Standard zurückgesetzt"
+  },
+  "showOlder": {
+    "message": "Ältere anzeigen"
+  },
+  "showOlderTitle": {
+    "message": "Ältere Nachrichten anzeigen"
+  },
+  "collapse": {
+    "message": "Einklappen"
+  },
+  "collapseTitle": {
+    "message": "Ältere Nachrichten einklappen"
+  },
+  "dragTitle": {
+    "message": "Ziehen"
+  },
+  "statusActive": {
+    "message": "GPT Boost aktiv"
+  }
+}

--- a/assets/locales/el/messages.json
+++ b/assets/locales/el/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Φορτώστε σταδιακά τις μεγάλες συνομιλίες του ChatGPT προβάλλοντας μόνο τα πιο πρόσφατα μηνύματα (παραμετροποιήσιμο). Μειώνει την καθυστέρηση σε μεγάλες συνομιλίες."
+  },
+  "statusBar": {
+    "message": "GPT Boost · ορατά $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "Έχει αποκρυφτεί 1 παλαιότερο μήνυμα — κάντε κλικ για να φορτώσετε τα επόμενα $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "Έχουν αποκρυφτεί $1 παλαιότερα μηνύματα — κάντε κλικ για να φορτώσετε τα επόμενα $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Επιλογές"
+  },
+  "labelMaxVisible": {
+    "message": "Μέγιστος αριθμός ορατών μηνυμάτων"
+  },
+  "defaultNumber": {
+    "message": "Προεπιλογή: $1"
+  },
+  "labelBatchSize": {
+    "message": "Μέγεθος παρτίδας (ανά εμφάνιση)"
+  },
+  "labelAutoload": {
+    "message": "Να εμφανίζονται αυτόματα τα παλαιότερα μηνύματα όταν κάνω κύλιση προς τα πάνω"
+  },
+  "labelHideOldest": {
+    "message": "Απόκρυψη του παλαιότερου μηνύματος όταν εμφανίζεται ένα νέο"
+  },
+  "save": {
+    "message": "Αποθήκευση"
+  },
+  "reset": {
+    "message": "Επαναφορά στις προεπιλογές"
+  },
+  "hintApply": {
+    "message": "Οι αλλαγές εφαρμόζονται αμέσως στις ανοιχτές καρτέλες του ChatGPT."
+  },
+  "footerDescription": {
+    "message": "Το $1 μειώνει την καθυστέρηση σε μεγάλες συνομιλίες διατηρώντας μόνο ένα παράθυρο μηνυμάτων στο DOM."
+  },
+  "footerSupportPrefix": {
+    "message": "Αν σας αρέσει αυτή η επέκταση, σκεφτείτε να μου αγοράσετε "
+  },
+  "footerSupportLinkText": {
+    "message": "έναν καφέ"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Οι ρυθμίσεις αποθηκεύτηκαν"
+  },
+  "settingsRestored": {
+    "message": "Οι ρυθμίσεις επανήλθαν στις προεπιλογές"
+  },
+  "showOlder": {
+    "message": "Εμφάνιση παλαιότερων"
+  },
+  "showOlderTitle": {
+    "message": "Εμφάνιση παλαιότερων μηνυμάτων"
+  },
+  "collapse": {
+    "message": "Σύμπτυξη"
+  },
+  "collapseTitle": {
+    "message": "Σύμπτυξη παλαιότερων μηνυμάτων"
+  },
+  "dragTitle": {
+    "message": "Σύρετε"
+  },
+  "statusActive": {
+    "message": "Το GPT Boost είναι ενεργό"
+  }
+}

--- a/assets/locales/es/messages.json
+++ b/assets/locales/es/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Carga de forma progresiva las conversaciones largas de ChatGPT mostrando solo los mensajes más recientes (configurable). Reduce el retraso en los chats largos."
+  },
+  "statusBar": {
+    "message": "GPT Boost · visibles $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 mensaje antiguo oculto — haz clic para cargar los siguientes $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 mensajes antiguos ocultos — haz clic para cargar los siguientes $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Opciones"
+  },
+  "labelMaxVisible": {
+    "message": "Máximo de mensajes visibles"
+  },
+  "defaultNumber": {
+    "message": "Predeterminado: $1"
+  },
+  "labelBatchSize": {
+    "message": "Tamaño del lote (por revelación)"
+  },
+  "labelAutoload": {
+    "message": "Mostrar mensajes antiguos automáticamente cuando desplazo hasta arriba"
+  },
+  "labelHideOldest": {
+    "message": "Ocultar el mensaje más antiguo cuando llegue uno nuevo"
+  },
+  "save": {
+    "message": "Guardar"
+  },
+  "reset": {
+    "message": "Restablecer valores predeterminados"
+  },
+  "hintApply": {
+    "message": "Los cambios se aplican al instante en las pestañas de ChatGPT abiertas."
+  },
+  "footerDescription": {
+    "message": "$1 reduce el retraso en conversaciones largas al mantener solo una ventana de mensajes en el DOM."
+  },
+  "footerSupportPrefix": {
+    "message": "Si te gusta esta extensión, piensa en invitarme "
+  },
+  "footerSupportLinkText": {
+    "message": "a un café"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Configuración guardada"
+  },
+  "settingsRestored": {
+    "message": "Configuración restablecida a los valores predeterminados"
+  },
+  "showOlder": {
+    "message": "Mostrar antiguos"
+  },
+  "showOlderTitle": {
+    "message": "Mostrar mensajes antiguos"
+  },
+  "collapse": {
+    "message": "Contraer"
+  },
+  "collapseTitle": {
+    "message": "Contraer mensajes antiguos"
+  },
+  "dragTitle": {
+    "message": "Arrastrar"
+  },
+  "statusActive": {
+    "message": "GPT Boost activo"
+  }
+}

--- a/assets/locales/fi/messages.json
+++ b/assets/locales/fi/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Lataa pitkät ChatGPT-keskustelut vaiheittain näyttämällä vain uusimmat viestit (muokattavissa). Vähentää viivettä pitkillä chatteilla."
+  },
+  "statusBar": {
+    "message": "GPT Boost · näkyvissä $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 vanhempi viesti piilotettu — lataa seuraavat $1 napsauttamalla"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 vanhempaa viestiä piilotettu — lataa seuraavat $2 napsauttamalla"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Asetukset"
+  },
+  "labelMaxVisible": {
+    "message": "Näkyvissä olevien viestien enimmäismäärä"
+  },
+  "defaultNumber": {
+    "message": "Oletus: $1"
+  },
+  "labelBatchSize": {
+    "message": "Eräkoko (per paljastus)"
+  },
+  "labelAutoload": {
+    "message": "Näytä vanhemmat viestit automaattisesti, kun vieritän ylös"
+  },
+  "labelHideOldest": {
+    "message": "Piilota vanhin viesti, kun uusi saapuu"
+  },
+  "save": {
+    "message": "Tallenna"
+  },
+  "reset": {
+    "message": "Palauta oletukset"
+  },
+  "hintApply": {
+    "message": "Muutokset tulevat voimaan heti avoimissa ChatGPT-välilehdissä."
+  },
+  "footerDescription": {
+    "message": "$1 vähentää viivettä pitkissä keskusteluissa pitämällä DOMissa vain viesti-ikkunan."
+  },
+  "footerSupportPrefix": {
+    "message": "Jos pidät tästä laajennuksesta, harkitse että tarjoat minulle "
+  },
+  "footerSupportLinkText": {
+    "message": "kahvin"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Asetukset tallennettu"
+  },
+  "settingsRestored": {
+    "message": "Asetukset palautettu oletuksiin"
+  },
+  "showOlder": {
+    "message": "Näytä vanhemmat"
+  },
+  "showOlderTitle": {
+    "message": "Näytä vanhemmat viestit"
+  },
+  "collapse": {
+    "message": "Tiivistä"
+  },
+  "collapseTitle": {
+    "message": "Tiivistä vanhemmat viestit"
+  },
+  "dragTitle": {
+    "message": "Vedä"
+  },
+  "statusActive": {
+    "message": "GPT Boost käytössä"
+  }
+}

--- a/assets/locales/hi/messages.json
+++ b/assets/locales/hi/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "लंबी ChatGPT बातचीत को केवल नवीनतम संदेश दिखाते हुए (अनुकूलन योग्य) धीरे-धीरे लोड करें। लंबे चैट में लग कम करता है।"
+  },
+  "statusBar": {
+    "message": "GPT Boost · दृश्यमान $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 पुराना संदेश छिपाया गया है — अगले $1 लोड करने के लिए क्लिक करें"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 पुराने संदेश छिपाए गए हैं — अगले $2 लोड करने के लिए क्लिक करें"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – विकल्प"
+  },
+  "labelMaxVisible": {
+    "message": "अधिकतम दृश्य संदेश"
+  },
+  "defaultNumber": {
+    "message": "डिफ़ॉल्ट: $1"
+  },
+  "labelBatchSize": {
+    "message": "बैच का आकार (प्रत्येक बार)"
+  },
+  "labelAutoload": {
+    "message": "जब मैं ऊपर स्क्रॉल करूँ तो पुराने संदेश स्वतः दिखाएँ"
+  },
+  "labelHideOldest": {
+    "message": "नया संदेश आने पर सबसे पुराना संदेश छिपाएँ"
+  },
+  "save": {
+    "message": "सहेजें"
+  },
+  "reset": {
+    "message": "डिफ़ॉल्ट पर रीसेट करें"
+  },
+  "hintApply": {
+    "message": "परिवर्तन खुले ChatGPT टैब पर तुरंत लागू होते हैं।"
+  },
+  "footerDescription": {
+    "message": "$1 लंबे वार्तालापों में केवल संदेशों की एक विंडो DOM में रखकर लग कम करता है।"
+  },
+  "footerSupportPrefix": {
+    "message": "यदि आपको यह एक्सटेंशन पसंद है, तो कृपया मुझे "
+  },
+  "footerSupportLinkText": {
+    "message": "एक कॉफी"
+  },
+  "footerSupportSuffix": {
+    "message": " खरीदने पर विचार करें।"
+  },
+  "settingsSaved": {
+    "message": "सेटिंग्स सहेजी गईं"
+  },
+  "settingsRestored": {
+    "message": "सेटिंग्स डिफ़ॉल्ट पर रीसेट की गईं"
+  },
+  "showOlder": {
+    "message": "पुराने दिखाएँ"
+  },
+  "showOlderTitle": {
+    "message": "पुराने संदेश दिखाएँ"
+  },
+  "collapse": {
+    "message": "सिकोड़ें"
+  },
+  "collapseTitle": {
+    "message": "पुराने संदेश सिकोड़ें"
+  },
+  "dragTitle": {
+    "message": "खींचें"
+  },
+  "statusActive": {
+    "message": "GPT Boost सक्रिय"
+  }
+}

--- a/assets/locales/it/messages.json
+++ b/assets/locales/it/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Carica progressivamente le conversazioni lunghe di ChatGPT mostrando solo i messaggi più recenti (configurabile). Riduce il ritardo nelle chat lunghe."
+  },
+  "statusBar": {
+    "message": "GPT Boost · visibili $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 messaggio precedente nascosto — clicca per caricare i successivi $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 messaggi precedenti nascosti — clicca per caricare i successivi $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Opzioni"
+  },
+  "labelMaxVisible": {
+    "message": "Numero massimo di messaggi visibili"
+  },
+  "defaultNumber": {
+    "message": "Predefinito: $1"
+  },
+  "labelBatchSize": {
+    "message": "Dimensione del lotto (per ogni visualizzazione)"
+  },
+  "labelAutoload": {
+    "message": "Mostra automaticamente i messaggi più vecchi quando scorro verso l'alto"
+  },
+  "labelHideOldest": {
+    "message": "Nascondi il messaggio più vecchio quando ne arriva uno nuovo"
+  },
+  "save": {
+    "message": "Salva"
+  },
+  "reset": {
+    "message": "Ripristina predefiniti"
+  },
+  "hintApply": {
+    "message": "Le modifiche vengono applicate immediatamente alle schede ChatGPT aperte."
+  },
+  "footerDescription": {
+    "message": "$1 riduce il ritardo nelle conversazioni lunghe mantenendo nel DOM solo una finestra di messaggi."
+  },
+  "footerSupportPrefix": {
+    "message": "Se ti piace questa estensione, considera di offrirmi "
+  },
+  "footerSupportLinkText": {
+    "message": "un caffè"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Impostazioni salvate"
+  },
+  "settingsRestored": {
+    "message": "Impostazioni ripristinate ai valori predefiniti"
+  },
+  "showOlder": {
+    "message": "Mostra più vecchi"
+  },
+  "showOlderTitle": {
+    "message": "Mostra messaggi più vecchi"
+  },
+  "collapse": {
+    "message": "Comprimi"
+  },
+  "collapseTitle": {
+    "message": "Comprimi i messaggi più vecchi"
+  },
+  "dragTitle": {
+    "message": "Trascina"
+  },
+  "statusActive": {
+    "message": "GPT Boost attivo"
+  }
+}

--- a/assets/locales/ja/messages.json
+++ b/assets/locales/ja/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "最新のメッセージだけを表示して（設定可能）長い ChatGPT の会話を遅延読み込みします。長いチャットの遅延を軽減します。"
+  },
+  "statusBar": {
+    "message": "GPT Boost · 表示中 $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "古いメッセージ 1 件を非表示にしました — 次の $1 件を読み込むにはクリック"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "古いメッセージ $1 件を非表示にしました — 次の $2 件を読み込むにはクリック"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – オプション"
+  },
+  "labelMaxVisible": {
+    "message": "表示する最大メッセージ数"
+  },
+  "defaultNumber": {
+    "message": "既定値: $1"
+  },
+  "labelBatchSize": {
+    "message": "バッチサイズ（1 回の表示）"
+  },
+  "labelAutoload": {
+    "message": "上までスクロールしたときに古いメッセージを自動的に表示する"
+  },
+  "labelHideOldest": {
+    "message": "新しいメッセージが届いたら最も古いメッセージを非表示にする"
+  },
+  "save": {
+    "message": "保存"
+  },
+  "reset": {
+    "message": "既定にリセット"
+  },
+  "hintApply": {
+    "message": "変更は開いている ChatGPT タブにすぐに適用されます。"
+  },
+  "footerDescription": {
+    "message": "$1 は DOM にメッセージのウィンドウだけを保持することで長い会話の遅延を減らします。"
+  },
+  "footerSupportPrefix": {
+    "message": "この拡張機能が気に入ったら、よかったら"
+  },
+  "footerSupportLinkText": {
+    "message": "コーヒー"
+  },
+  "footerSupportSuffix": {
+    "message": "をごちそうしてください。"
+  },
+  "settingsSaved": {
+    "message": "設定を保存しました"
+  },
+  "settingsRestored": {
+    "message": "設定を既定値に戻しました"
+  },
+  "showOlder": {
+    "message": "過去を表示"
+  },
+  "showOlderTitle": {
+    "message": "過去のメッセージを表示"
+  },
+  "collapse": {
+    "message": "折りたたむ"
+  },
+  "collapseTitle": {
+    "message": "過去のメッセージを折りたたむ"
+  },
+  "dragTitle": {
+    "message": "ドラッグ"
+  },
+  "statusActive": {
+    "message": "GPT Boost は有効です"
+  }
+}

--- a/assets/locales/nl/messages.json
+++ b/assets/locales/nl/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Laad lange ChatGPT-gesprekken geleidelijk door alleen de meest recente berichten te tonen (instelbaar). Vermindert vertraging in lange chats."
+  },
+  "statusBar": {
+    "message": "GPT Boost · zichtbaar $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 ouder bericht verborgen — klik om de volgende $1 te laden"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 oudere berichten verborgen — klik om de volgende $2 te laden"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Opties"
+  },
+  "labelMaxVisible": {
+    "message": "Maximaal aantal zichtbare berichten"
+  },
+  "defaultNumber": {
+    "message": "Standaard: $1"
+  },
+  "labelBatchSize": {
+    "message": "Batchgrootte (per keer tonen)"
+  },
+  "labelAutoload": {
+    "message": "Toon oudere berichten automatisch wanneer ik naar boven scroll"
+  },
+  "labelHideOldest": {
+    "message": "Verberg het oudste bericht wanneer er een nieuw binnenkomt"
+  },
+  "save": {
+    "message": "Opslaan"
+  },
+  "reset": {
+    "message": "Standaardinstellingen herstellen"
+  },
+  "hintApply": {
+    "message": "Wijzigingen worden direct toegepast op geopende ChatGPT-tabbladen."
+  },
+  "footerDescription": {
+    "message": "$1 vermindert vertraging in lange gesprekken door alleen een venster met berichten in de DOM te laten."
+  },
+  "footerSupportPrefix": {
+    "message": "Als je deze extensie waardeert, overweeg dan om mij "
+  },
+  "footerSupportLinkText": {
+    "message": "een kop koffie"
+  },
+  "footerSupportSuffix": {
+    "message": " te trakteren."
+  },
+  "settingsSaved": {
+    "message": "Instellingen opgeslagen"
+  },
+  "settingsRestored": {
+    "message": "Instellingen hersteld naar standaardwaarden"
+  },
+  "showOlder": {
+    "message": "Toon oudere"
+  },
+  "showOlderTitle": {
+    "message": "Toon oudere berichten"
+  },
+  "collapse": {
+    "message": "Samenvouwen"
+  },
+  "collapseTitle": {
+    "message": "Vouw oudere berichten samen"
+  },
+  "dragTitle": {
+    "message": "Slepen"
+  },
+  "statusActive": {
+    "message": "GPT Boost actief"
+  }
+}

--- a/assets/locales/no/messages.json
+++ b/assets/locales/no/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Last inn lange ChatGPT-samtaler etter behov ved å vise bare de nyeste meldingene (kan konfigureres). Reduserer forsinkelser i lange chatter."
+  },
+  "statusBar": {
+    "message": "GPT Boost · synlige $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 eldre melding skjult – klikk for å laste inn de neste $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 eldre meldinger skjult – klikk for å laste inn de neste $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Alternativer"
+  },
+  "labelMaxVisible": {
+    "message": "Maksimalt antall synlige meldinger"
+  },
+  "defaultNumber": {
+    "message": "Standard: $1"
+  },
+  "labelBatchSize": {
+    "message": "Batchstørrelse (per visning)"
+  },
+  "labelAutoload": {
+    "message": "Vis eldre meldinger automatisk når jeg ruller til toppen"
+  },
+  "labelHideOldest": {
+    "message": "Skjul den eldste meldingen når en ny kommer"
+  },
+  "save": {
+    "message": "Lagre"
+  },
+  "reset": {
+    "message": "Tilbakestill til standard"
+  },
+  "hintApply": {
+    "message": "Endringene gjelder umiddelbart i åpne ChatGPT-faner."
+  },
+  "footerDescription": {
+    "message": "$1 reduserer forsinkelser i lange samtaler ved å bare beholde et meldingsvindu i DOM-en."
+  },
+  "footerSupportPrefix": {
+    "message": "Hvis du liker denne utvidelsen, vurder å spandere "
+  },
+  "footerSupportLinkText": {
+    "message": "en kaffe"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Innstillinger lagret"
+  },
+  "settingsRestored": {
+    "message": "Innstillinger tilbakestilt til standard"
+  },
+  "showOlder": {
+    "message": "Vis eldre"
+  },
+  "showOlderTitle": {
+    "message": "Vis eldre meldinger"
+  },
+  "collapse": {
+    "message": "Skjul"
+  },
+  "collapseTitle": {
+    "message": "Skjul eldre meldinger"
+  },
+  "dragTitle": {
+    "message": "Dra"
+  },
+  "statusActive": {
+    "message": "GPT Boost aktiv"
+  }
+}

--- a/assets/locales/pl/messages.json
+++ b/assets/locales/pl/messages.json
@@ -3,78 +3,78 @@
     "message": "GPT Boost"
   },
   "appDescription": {
-    "message": "Zoptymalizowanie długich konwersacji ChatGPT poprzez wyświetlanie tylko najnowszych wiadomości (konfigurowalne). Zmniejsza opóźnienia przy długich czatach."
+    "message": "Ładuj długie rozmowy ChatGPT na żądanie, wyświetlając tylko najnowsze wiadomości (konfigurowalne). Zmniejsza opóźnienia przy długich czatach."
   },
   "statusBar": {
-    "message": "GPT Boost · visible $1/$2"
+    "message": "GPT Boost · widoczne $1/$2"
   },
   "hiddenPlaceholderSingular": {
-    "message": "1 older message hidden — click to load next $1"
+    "message": "Ukryto 1 starszą wiadomość — kliknij, aby wczytać kolejne $1"
   },
   "hiddenPlaceholderPlural": {
-    "message": "$1 older messages hidden — click to load next $2"
+    "message": "Ukryto $1 starszych wiadomości — kliknij, aby wczytać kolejne $2"
   },
   "optionsTitle": {
-    "message": "GPT Boost – Options"
+    "message": "GPT Boost – Opcje"
   },
   "labelMaxVisible": {
-    "message": "Max visible messages"
+    "message": "Maksymalna liczba widocznych wiadomości"
   },
   "defaultNumber": {
-    "message": "Default: $1"
+    "message": "Domyślnie: $1"
   },
   "labelBatchSize": {
-    "message": "Batch size (per reveal)"
+    "message": "Wielkość partii (na odsłonięcie)"
   },
   "labelAutoload": {
-    "message": "Reveal older messages automatically when I scroll to the top"
+    "message": "Automatycznie pokazuj starsze wiadomości, gdy przewijam do góry"
   },
   "labelHideOldest": {
-    "message": "Hide the oldest message when a new appears"
+    "message": "Ukrywaj najstarszą wiadomość, gdy pojawi się nowa"
   },
   "save": {
-    "message": "Save"
+    "message": "Zapisz"
   },
   "reset": {
-    "message": "Reset to defaults"
+    "message": "Przywróć domyślne"
   },
   "hintApply": {
-    "message": "Changes apply instantly to open ChatGPT tabs."
+    "message": "Zmiany są stosowane natychmiast na otwartych kartach ChatGPT."
   },
   "footerDescription": {
-    "message": "$1 reduces lag on long conversations by only keeping a window of messages in the DOM."
+    "message": "$1 zmniejsza opóźnienia w długich rozmowach, pozostawiając w DOM jedynie okno wiadomości."
   },
   "footerSupportPrefix": {
-    "message": "If you like this extension consider buying me "
+    "message": "Jeśli podoba Ci się to rozszerzenie, rozważ postawienie mi "
   },
   "footerSupportLinkText": {
-    "message": "a coffee"
+    "message": "kawy"
   },
   "footerSupportSuffix": {
     "message": "."
   },
   "settingsSaved": {
-    "message": "Settings saved"
+    "message": "Ustawienia zapisane"
   },
   "settingsRestored": {
-    "message": "Settings restored to defaults"
+    "message": "Przywrócono ustawienia domyślne"
   },
   "showOlder": {
-    "message": "Show older"
+    "message": "Pokaż starsze"
   },
   "showOlderTitle": {
-    "message": "Show older messages"
+    "message": "Pokaż starsze wiadomości"
   },
   "collapse": {
-    "message": "Collapse"
+    "message": "Zwiń"
   },
   "collapseTitle": {
-    "message": "Collapse older messages"
+    "message": "Zwiń starsze wiadomości"
   },
   "dragTitle": {
-    "message": "Drag"
+    "message": "Przeciągnij"
   },
   "statusActive": {
-    "message": "GPT Boost active"
+    "message": "GPT Boost aktywny"
   }
 }

--- a/assets/locales/ru/messages.json
+++ b/assets/locales/ru/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Загружайте длинные беседы ChatGPT по мере необходимости, показывая только самые последние сообщения (настраивается). Уменьшает задержки в длинных чатах."
+  },
+  "statusBar": {
+    "message": "GPT Boost · видно $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "Скрыто 1 старое сообщение — нажмите, чтобы загрузить следующие $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "Скрыто $1 старых сообщений — нажмите, чтобы загрузить следующие $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Настройки"
+  },
+  "labelMaxVisible": {
+    "message": "Максимум видимых сообщений"
+  },
+  "defaultNumber": {
+    "message": "По умолчанию: $1"
+  },
+  "labelBatchSize": {
+    "message": "Размер пакета (за одно раскрытие)"
+  },
+  "labelAutoload": {
+    "message": "Автоматически показывать старые сообщения при прокрутке вверх"
+  },
+  "labelHideOldest": {
+    "message": "Скрывать самое старое сообщение, когда появляется новое"
+  },
+  "save": {
+    "message": "Сохранить"
+  },
+  "reset": {
+    "message": "Сбросить по умолчанию"
+  },
+  "hintApply": {
+    "message": "Изменения применяются мгновенно на открытых вкладках ChatGPT."
+  },
+  "footerDescription": {
+    "message": "$1 уменьшает задержки в длинных беседах, оставляя в DOM только окно сообщений."
+  },
+  "footerSupportPrefix": {
+    "message": "Если вам нравится это расширение, подумайте о том, чтобы угостить меня "
+  },
+  "footerSupportLinkText": {
+    "message": "кофе"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Настройки сохранены"
+  },
+  "settingsRestored": {
+    "message": "Настройки сброшены к значениям по умолчанию"
+  },
+  "showOlder": {
+    "message": "Показать старые"
+  },
+  "showOlderTitle": {
+    "message": "Показать старые сообщения"
+  },
+  "collapse": {
+    "message": "Свернуть"
+  },
+  "collapseTitle": {
+    "message": "Свернуть старые сообщения"
+  },
+  "dragTitle": {
+    "message": "Перетащить"
+  },
+  "statusActive": {
+    "message": "GPT Boost активен"
+  }
+}

--- a/assets/locales/sr/messages.json
+++ b/assets/locales/sr/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Учитавајте дуге ChatGPT разговоре постепено приказујући само најновије поруке (може се подесити). Смањује кашњење у дугим четовима."
+  },
+  "statusBar": {
+    "message": "GPT Boost · видљиво $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 старија порука је скривена — кликните да учитате наредних $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "Скривено је $1 старијих порука — кликните да учитате наредних $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Подешавања"
+  },
+  "labelMaxVisible": {
+    "message": "Максималан број видљивих порука"
+  },
+  "defaultNumber": {
+    "message": "Подразумевано: $1"
+  },
+  "labelBatchSize": {
+    "message": "Величина серије (по откривању)"
+  },
+  "labelAutoload": {
+    "message": "Аутоматски прикажи старије поруке када се померам на врх"
+  },
+  "labelHideOldest": {
+    "message": "Сакриј најстарију поруку када се појави нова"
+  },
+  "save": {
+    "message": "Сачувај"
+  },
+  "reset": {
+    "message": "Врати на подразумевано"
+  },
+  "hintApply": {
+    "message": "Промене се одмах примењују на отвореним ChatGPT картицама."
+  },
+  "footerDescription": {
+    "message": "$1 смањује кашњење у дугим разговорима тако што у DOM-у задржава само прозор порука."
+  },
+  "footerSupportPrefix": {
+    "message": "Ако вам се допада ово проширење, размислите да ми купите "
+  },
+  "footerSupportLinkText": {
+    "message": "кафу"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Подешавања су сачувана"
+  },
+  "settingsRestored": {
+    "message": "Подешавања враћена на подразумеване вредности"
+  },
+  "showOlder": {
+    "message": "Прикажи старије"
+  },
+  "showOlderTitle": {
+    "message": "Прикажи старије поруке"
+  },
+  "collapse": {
+    "message": "Скупи"
+  },
+  "collapseTitle": {
+    "message": "Скупи старије поруке"
+  },
+  "dragTitle": {
+    "message": "Превуци"
+  },
+  "statusActive": {
+    "message": "GPT Boost је активан"
+  }
+}

--- a/assets/locales/tr/messages.json
+++ b/assets/locales/tr/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Uzun ChatGPT sohbetlerini yalnızca en yeni iletileri göstererek (özelleştirilebilir) kademeli olarak yükleyin. Uzun sohbetlerdeki gecikmeyi azaltır."
+  },
+  "statusBar": {
+    "message": "GPT Boost · görünür $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "1 eski ileti gizlendi — sonraki $1 iletiyi yüklemek için tıklayın"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "$1 eski ileti gizlendi — sonraki $2 iletiyi yüklemek için tıklayın"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Seçenekler"
+  },
+  "labelMaxVisible": {
+    "message": "Görünür iletilerin en yüksek sayısı"
+  },
+  "defaultNumber": {
+    "message": "Varsayılan: $1"
+  },
+  "labelBatchSize": {
+    "message": "Toplu gösterim boyutu (her seferinde)"
+  },
+  "labelAutoload": {
+    "message": "Yukarı kaydırdığımda eski iletileri otomatik olarak göster"
+  },
+  "labelHideOldest": {
+    "message": "Yeni bir ileti geldiğinde en eski iletiyi gizle"
+  },
+  "save": {
+    "message": "Kaydet"
+  },
+  "reset": {
+    "message": "Varsayılanlara sıfırla"
+  },
+  "hintApply": {
+    "message": "Değişiklikler açık ChatGPT sekmelerine anında uygulanır."
+  },
+  "footerDescription": {
+    "message": "$1, DOM'da yalnızca bir ileti penceresi tutarak uzun konuşmalardaki gecikmeyi azaltır."
+  },
+  "footerSupportPrefix": {
+    "message": "Bu uzantıyı beğendiyseniz, lütfen bana "
+  },
+  "footerSupportLinkText": {
+    "message": "bir kahve"
+  },
+  "footerSupportSuffix": {
+    "message": " ısmarlamayı düşünün."
+  },
+  "settingsSaved": {
+    "message": "Ayarlar kaydedildi"
+  },
+  "settingsRestored": {
+    "message": "Ayarlar varsayılanlara sıfırlandı"
+  },
+  "showOlder": {
+    "message": "Eskileri göster"
+  },
+  "showOlderTitle": {
+    "message": "Eski iletileri göster"
+  },
+  "collapse": {
+    "message": "Daralt"
+  },
+  "collapseTitle": {
+    "message": "Eski iletileri daralt"
+  },
+  "dragTitle": {
+    "message": "Sürükle"
+  },
+  "statusActive": {
+    "message": "GPT Boost etkin"
+  }
+}

--- a/assets/locales/uk/messages.json
+++ b/assets/locales/uk/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "Завантажуйте довгі розмови ChatGPT поступово, показуючи лише найновіші повідомлення (налаштовується). Зменшує затримки в довгих чатах."
+  },
+  "statusBar": {
+    "message": "GPT Boost · видно $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "Приховано 1 старе повідомлення — натисніть, щоб завантажити наступні $1"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "Приховано $1 старих повідомлень — натисніть, щоб завантажити наступні $2"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – Параметри"
+  },
+  "labelMaxVisible": {
+    "message": "Максимальна кількість видимих повідомлень"
+  },
+  "defaultNumber": {
+    "message": "Типово: $1"
+  },
+  "labelBatchSize": {
+    "message": "Розмір пакета (за одне показування)"
+  },
+  "labelAutoload": {
+    "message": "Автоматично показувати старі повідомлення, коли я прокручую догори"
+  },
+  "labelHideOldest": {
+    "message": "Приховувати найстаріше повідомлення, коли з’являється нове"
+  },
+  "save": {
+    "message": "Зберегти"
+  },
+  "reset": {
+    "message": "Скинути до типових"
+  },
+  "hintApply": {
+    "message": "Зміни застосовуються миттєво на відкритих вкладках ChatGPT."
+  },
+  "footerDescription": {
+    "message": "$1 зменшує затримки в довгих розмовах, залишаючи в DOM лише вікно повідомлень."
+  },
+  "footerSupportPrefix": {
+    "message": "Якщо вам подобається це розширення, розгляньте можливість пригостити мене "
+  },
+  "footerSupportLinkText": {
+    "message": "кавою"
+  },
+  "footerSupportSuffix": {
+    "message": "."
+  },
+  "settingsSaved": {
+    "message": "Налаштування збережено"
+  },
+  "settingsRestored": {
+    "message": "Налаштування скинуто до типових"
+  },
+  "showOlder": {
+    "message": "Показати старі"
+  },
+  "showOlderTitle": {
+    "message": "Показати старі повідомлення"
+  },
+  "collapse": {
+    "message": "Згорнути"
+  },
+  "collapseTitle": {
+    "message": "Згорнути старі повідомлення"
+  },
+  "dragTitle": {
+    "message": "Перетягнути"
+  },
+  "statusActive": {
+    "message": "GPT Boost активний"
+  }
+}

--- a/assets/locales/zh_CN/messages.json
+++ b/assets/locales/zh_CN/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "通过仅显示最新消息（可配置）来按需加载冗长的 ChatGPT 对话。减少长聊天的卡顿。"
+  },
+  "statusBar": {
+    "message": "GPT Boost · 可见 $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "隐藏了 1 条较早消息 — 点击加载接下来的 $1 条"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "隐藏了 $1 条较早消息 — 点击加载接下来的 $2 条"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – 选项"
+  },
+  "labelMaxVisible": {
+    "message": "最多可见消息数"
+  },
+  "defaultNumber": {
+    "message": "默认：$1"
+  },
+  "labelBatchSize": {
+    "message": "批量大小（每次显示）"
+  },
+  "labelAutoload": {
+    "message": "当我滚动到顶部时自动显示较早消息"
+  },
+  "labelHideOldest": {
+    "message": "出现新消息时隐藏最早的一条"
+  },
+  "save": {
+    "message": "保存"
+  },
+  "reset": {
+    "message": "重置为默认值"
+  },
+  "hintApply": {
+    "message": "更改会立即应用到已打开的 ChatGPT 标签页。"
+  },
+  "footerDescription": {
+    "message": "$1 通过只在 DOM 中保留一段消息窗口来减少长对话的卡顿。"
+  },
+  "footerSupportPrefix": {
+    "message": "如果你喜欢这个扩展，请考虑请我喝"
+  },
+  "footerSupportLinkText": {
+    "message": "杯咖啡"
+  },
+  "footerSupportSuffix": {
+    "message": "。"
+  },
+  "settingsSaved": {
+    "message": "设置已保存"
+  },
+  "settingsRestored": {
+    "message": "设置已恢复为默认值"
+  },
+  "showOlder": {
+    "message": "显示较早"
+  },
+  "showOlderTitle": {
+    "message": "显示较早的消息"
+  },
+  "collapse": {
+    "message": "收起"
+  },
+  "collapseTitle": {
+    "message": "收起较早的消息"
+  },
+  "dragTitle": {
+    "message": "拖动"
+  },
+  "statusActive": {
+    "message": "GPT Boost 已启用"
+  }
+}

--- a/assets/locales/zh_TW/messages.json
+++ b/assets/locales/zh_TW/messages.json
@@ -1,0 +1,80 @@
+{
+  "appName": {
+    "message": "GPT Boost"
+  },
+  "appDescription": {
+    "message": "透過只顯示最新訊息（可設定）來按需載入冗長的 ChatGPT 對話。減少長時間聊天的延遲。"
+  },
+  "statusBar": {
+    "message": "GPT Boost · 可見 $1/$2"
+  },
+  "hiddenPlaceholderSingular": {
+    "message": "已隱藏 1 則較早的訊息 — 點擊載入接下來的 $1 則"
+  },
+  "hiddenPlaceholderPlural": {
+    "message": "已隱藏 $1 則較早的訊息 — 點擊載入接下來的 $2 則"
+  },
+  "optionsTitle": {
+    "message": "GPT Boost – 選項"
+  },
+  "labelMaxVisible": {
+    "message": "最多可見訊息數"
+  },
+  "defaultNumber": {
+    "message": "預設：$1"
+  },
+  "labelBatchSize": {
+    "message": "批次大小（每次顯示）"
+  },
+  "labelAutoload": {
+    "message": "當我捲動到頂端時自動顯示較早的訊息"
+  },
+  "labelHideOldest": {
+    "message": "出現新訊息時隱藏最早的那一則"
+  },
+  "save": {
+    "message": "儲存"
+  },
+  "reset": {
+    "message": "重設為預設值"
+  },
+  "hintApply": {
+    "message": "變更會立即套用到開啟的 ChatGPT 分頁。"
+  },
+  "footerDescription": {
+    "message": "$1 透過只在 DOM 中保留一個訊息視窗來減少長對話的延遲。"
+  },
+  "footerSupportPrefix": {
+    "message": "如果你喜歡這個擴充功能，請考慮請我喝"
+  },
+  "footerSupportLinkText": {
+    "message": "杯咖啡"
+  },
+  "footerSupportSuffix": {
+    "message": "。"
+  },
+  "settingsSaved": {
+    "message": "設定已儲存"
+  },
+  "settingsRestored": {
+    "message": "設定已重設為預設值"
+  },
+  "showOlder": {
+    "message": "顯示較早"
+  },
+  "showOlderTitle": {
+    "message": "顯示較早的訊息"
+  },
+  "collapse": {
+    "message": "收合"
+  },
+  "collapseTitle": {
+    "message": "收合較早的訊息"
+  },
+  "dragTitle": {
+    "message": "拖曳"
+  },
+  "statusActive": {
+    "message": "GPT Boost 已啟用"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,24 @@
   "xtbuild": {
     "locales_list": [
       "en",
-      "pl"
+      "pl",
+      "de",
+      "es",
+      "ru",
+      "zh_CN",
+      "zh_TW",
+      "uk",
+      "hi",
+      "ja",
+      "cs",
+      "ar",
+      "it",
+      "fi",
+      "no",
+      "nl",
+      "sr",
+      "tr",
+      "el"
     ],
     "js_bundles": [
       {


### PR DESCRIPTION
## Summary
- add localized message bundles for the requested languages
- improve the existing Polish translation to fully localize UI strings
- register all locales in the build configuration

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68cfe3cb5cf48329b31c1ad36457a58f